### PR TITLE
Replace funzip with unzip to handle zip files with multiple entries

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,7 +15,10 @@ TERRAFORM_ARCH="amd64" # or 386, arm, arm64
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION#v}/terraform_${TERRAFORM_VERSION#v}_${TERRAFORM_OS}_${TERRAFORM_ARCH}.zip"
 
 # TODO: Avoid installing if already installed at correct version
-curl --silent --show-error --location --output - "${TERRAFORM_URL}" | funzip > /usr/local/bin/terraform
+TERRAFORM_DOWNLOAD_FILE=$(mktemp)
+curl --silent --show-error --location --output "${TERRAFORM_DOWNLOAD_FILE}" "${TERRAFORM_URL}"
+unzip "${TERRAFORM_DOWNLOAD_FILE}" terraform -d /usr/local/bin
+rm "${TERRAFORM_DOWNLOAD_FILE}"
 
 chmod 0755 /usr/local/bin/terraform
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,7 +15,7 @@ TERRAFORM_ARCH="amd64" # or 386, arm, arm64
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION#v}/terraform_${TERRAFORM_VERSION#v}_${TERRAFORM_OS}_${TERRAFORM_ARCH}.zip"
 
 # TODO: Avoid installing if already installed at correct version
-TERRAFORM_DOWNLOAD_FILE=$(mktemp)
+TERRAFORM_DOWNLOAD_FILE="$(mktemp)"
 curl --silent --show-error --location --output "${TERRAFORM_DOWNLOAD_FILE}" "${TERRAFORM_URL}"
 unzip "${TERRAFORM_DOWNLOAD_FILE}" terraform -d /usr/local/bin
 rm "${TERRAFORM_DOWNLOAD_FILE}"


### PR DESCRIPTION
The ZIP archive of newer terraform versions (e.g. 1.11.1) seem to contain more than a single file entry:


```shell
~ » unzip -l terraform_1.11.1_linux_amd64.zip
Archive:  terraform_1.11.1_linux_amd64.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     4922  03-05-2025 22:51   LICENSE.txt
 89612440  03-05-2025 22:51   terraform
---------                     -------
 89617362                     2 files
```


`funzip` can't handle it:

```shell
funzip warning: zipfile has more than one entry--rest ignored
curl: (23) Failure writing output to destination
```

So this PR modifies `hooks/pre-command` to use `unzip` instead.